### PR TITLE
Feat/id selections all main tab panels

### DIFF
--- a/app.R
+++ b/app.R
@@ -200,10 +200,10 @@ ui <- page_sidebar(
     
     
     #filter 2 - ID - 2nd div
-    div(style = "border: 1px solid #ccc; padding: 10px; margin-bottom: 15px; border-radius: 8px;",
-        numericInput("num_value", "Enter a task number:", value = 1, min = 1, max = 1)
-    ),
-
+    # div(style = "border: 1px solid #ccc; padding: 10px; margin-bottom: 15px; border-radius: 8px;",
+    #     numericInput("num_value", "Enter a task number:", value = 1, min = 1, max = 1)
+    # ),
+    
     div(
       style = "text-align: left; color: #888; font-size: 12px;",
       "Version 1.1.1"
@@ -212,64 +212,10 @@ ui <- page_sidebar(
   
   # Main tabs
   tabsetPanel(
-    tabPanel('All tasks', uiOutput("file_selector_ui"),
-             uiOutput("player_info_box"),
-             DTOutput('iris_data'),
-             div(style = "border: 0px solid #ccc; padding: 10px; margin-top: 15px; border-radius: 8px;",
-                 uiOutput('save_big_table'))),
-    tabPanel('Map', h3("Maps"), card(uiOutput("file_selector_ui3"), textOutput("mapLegend"), div(id="map", leafletOutput("map"),  style = "margin-top: 5px"),
-             div(style = "border: 0px solid #ccc; padding: 10px; margin-top: 15px; border-radius: 8px;",
-                 downloadButton('downloadMap','Save the map')), full_screen = TRUE)),
-    tabPanel('Pictures', h3("Uploaded Photos"),
-             card(uiOutput("file_selector_ui4"),
-               uiOutput("photo_display"),
-               full_screen = TRUE
-             )
-    ),
-    tabPanel('All plays', uiOutput("file_selector_ui1"), textOutput("tabLegend"),
-             conditionalPanel(condition = "output.tabLegend == 'Task type: Navigation to flag' || output.tabLegend == 'Task type: Navigation with arrow' || output.tabLegend == 'Task type: Navigation via text' || output.tabLegend == 'Task type: Navigation via photo'",
-                              card(h4("Route length versus time"), tableOutput('cmp_table1'), downloadButton('save_table1', 'Save to csv'), style = "margin-top: 10px"),
-                              ),
-             conditionalPanel(condition = "output.tabLegend == 'Task type: Direction determination'",
-                              card(h4("Answer and error for direction task"), tableOutput('cmp_table2'), downloadButton('save_table2', 'Save to csv'), style = "margin-top: 10px")
-                              ),
-             ),
-    tabPanel('Statistics', h3("Statistics"),uiOutput("file_selector_ui2"), textOutput("graphLegend"),
-             #if the task category is navigation
-             conditionalPanel(condition = "output.graphLegend == 'Task type: Navigation to flag' || output.graphLegend == 'Task type: Navigation with arrow' || output.graphLegend == 'Task type: Navigation via text' || output.graphLegend == 'Task type: Navigation via photo'",
-                              selectInput(
-                                inputId = "graph_filter",
-                                label = "Choose graphic to display:",
-                                choices = c("Time VS Distance","Answer & Error"),
-                                selected = c("Answer & Error")
-                              ), conditionalPanel(
-                                condition = "input.graph_filter == 'Answer & Error'",
-                                card(card_header("Pie chart") , full_screen = TRUE, plotOutput('pie_chart'), 
-                                     div(style = "border: 0px solid #ccc; padding: 10px; margin-top: 15px; border-radius: 8px;",
-                                     downloadButton('save_picture','Save to png')))
-                              ), conditionalPanel(
-                                condition = "input.graph_filter == 'Time VS Distance'",
-                                card(card_header("Time vs distance scatter plot"), full_screen = TRUE, plotOutput('time_chart'), 
-                                     div(style = "border: 0px solid #ccc; padding: 10px; margin-top: 15px; border-radius: 8px;",
-                                     downloadButton('save_time_chart','Save to png')))
-                              )
-                              ),
-             #else, for the other tasks
-             conditionalPanel(condition = "output.graphLegend == 'Task type: Direction determination' || output.graphLegend == 'Task type: Free' || output.graphLegend == 'Task type: Self location' || output.graphLegend == 'Task type: Object location'",
-                              selectInput(
-                                inputId = "graph_filter2",
-                                label = "Choose graphic to display:",
-                                choices = c("Answer & Error"),
-                                selected = c("Answer & Error")
-                              ), conditionalPanel(
-                                condition = "input.graph_filter2 == 'Answer & Error'",
-                                card(card_header("Time vs distance scatter plot"), full_screen = TRUE, plotOutput('pie_chart2'),
-                                    div(style = "border: 0px solid #ccc; padding: 10px; margin-top: 15px; border-radius: 8px;",
-                                    downloadButton('save_picture2','Save to png')))
-                              ),
-                              ),
-            )
-  )
+        div(style = "min-width: 300px;", numericInput("num_value", "Selected Tasks:", value = 1, min = 1, max = 1)),
+        div(style = "min-width: 300px;", numericInput("num_value_pictures", "Selected Tasks:", value = 1, min = 1, max = 1)),
+            numericInput("num_value_comparison", "Selected Tasks:", value = 1, min = 1, max = 1)
+            numericInput("num_value_Statistics", "Selected Tasks:", value = 1, min = 1, max = 1)
 )
 
 
@@ -896,6 +842,21 @@ observeEvent(req(input$selected_data_file, input$num_value), {
     
     observe({
       updateNumericInput(session, "num_value", 
+                         max = nrow(df_react()))
+    })
+    
+    observe({
+      updateNumericInput(session, "num_value_pictures", 
+                         max = nrow(df_react()))
+    })
+    
+    observe({
+      updateNumericInput(session, "num_value_comparison", 
+                         max = nrow(df_react()))
+    })
+    
+    observe({
+      updateNumericInput(session, "num_value_Statistics", 
                          max = nrow(df_react()))
     })
     
@@ -1988,6 +1949,21 @@ observeEvent(req(input$selected_data_file, input$num_value), {
       updateNumericInput(session, "num_value", 
                          max = nrow(df_react()))
     })
+    observe({
+      updateNumericInput(session, "num_value_pictures", 
+                         max = nrow(df_react()))
+    })
+    
+    observe({
+      updateNumericInput(session, "num_value_comparison", 
+                         max = nrow(df_react()))
+    })
+    
+    observe({
+      updateNumericInput(session, "num_value_Statistics", 
+                         max = nrow(df_react()))
+    })
+    
     
     output$iris_data <- renderDT({
       df_react()

--- a/app.R
+++ b/app.R
@@ -1042,7 +1042,7 @@ observeEvent(req(input$selected_data_file, input$num_value), {
       if ((!is.na(id[i]) && (i != 1) && (id[i] != id[i + 1])) || i == (length(id) - 1)) {
         cou <- cou + 1
         pict <- append(pict, unlist(data[[1]]$events$task$question$photo[[i]]))
-        ans_photo <- append(ans_photo, unlist(data[[1]]$events$answer$photo$changingThisBreaksApplicationSecurity[[i]]))
+        ans_photo <- append(ans_photo, unlist(data[[1]]$events$answer$photo[[i]]))
       }
     }
     

--- a/app.R
+++ b/app.R
@@ -136,7 +136,20 @@ ui <- page_sidebar(
         max-width: 100% !important;
       }
     }
+    .selectize-control {
+      width: 100% !important;
+    }
+    .selectize-input {
+      width: 100% !important;
+    }
+    
 
+    /* Hover effect on main tabs */
+    .nav-tabs > li > a:hover {
+      background-color: #27E7F5 !important;  /* yellow on hover */
+      color: #000 !important;
+      border: 1px solid #ffc107;
+    }
   '))
   ),
   
@@ -212,10 +225,31 @@ ui <- page_sidebar(
   
   # Main tabs
   tabsetPanel(
+        div(style = "min-width: 300px;", uiOutput("task_id_selector")),
+        div(style = "min-width: 300px;", uiOutput("file_selector_ui"))
+      div(
+        style = "display: flex; justify-content: flex-start; gap: 40px; align-items: flex-start;
+             margin-top: 20px; margin-bottom: 15px;
+             border: 1px solid #ccc; padding: 10px;",
         div(style = "min-width: 300px;", numericInput("num_value", "Selected Tasks:", value = 1, min = 1, max = 1)),
+        div(style = "min-width: 300px;", uiOutput("file_selector_ui3"))
+        style = "display: flex; justify-content: flex-start; gap: 40px; align-items: flex-start;
+             margin-top: 20px; margin-bottom: 15px;
+             border: 1px solid #ccc; padding: 10px;",
         div(style = "min-width: 300px;", numericInput("num_value_pictures", "Selected Tasks:", value = 1, min = 1, max = 1)),
+        div(style = "min-width: 300px;", uiOutput("file_selector_ui4"))
+        style = "display: flex; justify-content: flex-start; gap: 40px; align-items: flex-start;
+           margin-top: 20px; margin-bottom: 15px;
+           border: 1px solid #ccc; padding: 10px;",
+        div(style = "min-width: 300px; max-width: 350px;", 
             numericInput("num_value_comparison", "Selected Tasks:", value = 1, min = 1, max = 1)
+        div(style = "flex: 1; max-width: 700px;", 
+        style = "display: flex; justify-content: flex-start; gap: 40px; align-items: flex-start;
+             margin-top: 20px; margin-bottom: 15px;
+             border: 1px solid #ccc; padding: 10px;",
+        div(style = "min-width: 300px;  max-width: 350px;", 
             numericInput("num_value_Statistics", "Selected Tasks:", value = 1, min = 1, max = 1)
+        div(style = "flex: 1; max-width: 700px;", 
 )
 
 

--- a/app.R
+++ b/app.R
@@ -2281,22 +2281,23 @@ observeEvent(req(input$selected_data_file, input$num_value), {
   
   
   #Download big table
-  output$save_data <- downloadHandler(
-    filename = function(){
-      paste("data_", Sys.Date(), ".csv", sep="")
-    },
-    content = function(file){
-      write.csv(df_react(), file)
-    }
-  )
+  all_ids <- c("num_value", "num_value_pictures", "num_value_comparison", "num_value_Statistics")
+  #NOTE : num_value is the important variable, all of the other stored elements are triggered because of 'num_value'
   
-  output$save_big_table <- renderUI({
-    req(input$selected_data_file)
-    
-    if (length(input$selected_data_file) > 0 && input$selected_data_file != "") {
-      downloadButton('save_data', 'Save to csv')
-    }
-  })
+  for (id in all_ids) {
+    local({
+      this_id <- id
+      observeEvent(input[[this_id]], {
+        val <- input[[this_id]]
+        if (is.null(val)) return()
+        
+        for (other in setdiff(all_ids, this_id)) {
+          if (is.null(input[[other]]) || !identical(val, input[[other]])) {
+            updateNumericInput(session, other, value = val)
+          }
+        }
+      }, ignoreInit = TRUE, ignoreNULL = TRUE)
+    })
   
 }
 

--- a/app.R
+++ b/app.R
@@ -427,47 +427,117 @@ server <- function(input, output, session) {
       return(track_data)
     })
   })
-
+  
   ### 9. UI: multiple file selector for comparison (tables, graphics, maps, photos)
+  # UI for Compare Players - with select/deselect buttons
   output$file_selector_ui1 <- renderUI({
     req(input$selected_files)
-
-    selectInput("selected_multiple_files", 
-                "Choose file to compare:", 
-                choices = input$selected_files,
-                selected = input$selected_files,
-                multiple = TRUE)
+    
+    tagList(
+      selectizeInput(
+        "selected_multiple_files", 
+        "Selected Players:", 
+        choices = input$selected_files,
+        selected = input$selected_files,
+        multiple = TRUE,
+        options = list(
+          plugins = list('remove_button')
+        )
+      ),
+      # Add select/deselect buttons
+      actionButton("select_all_players", "Select All"),
+      actionButton("deselect_all_players", "Reset")
+    )
   })
+  
+  
+  ####-------------'select and deselect all' buttons logic for file_selector_ui 1 that is 'compare' tab------------
+  # Select all players
+  observeEvent(input$select_all_players, {
+    req(input$selected_files)
+    updateSelectizeInput(
+      session,
+      "selected_multiple_files",
+      selected = input$selected_files
+    )
+  })
+  
+  # Deselect all players
+  observeEvent(input$deselect_all_players, {
+    updateSelectizeInput(
+      session,
+      "selected_multiple_files",
+      selected = character(0)
+    )
+  })
+  ####-------------'select and deselect all' buttons logic for file_selector_ui 1 that is 'compare' tab ENDS------------
+  
+  
   
   ##### Filters for comparing Graphics starts
   output$file_selector_ui2 <- renderUI({
     req(input$selected_files)
     
-    selectInput("selected_multiple_files", 
-                "Choose file to compare:", 
-                choices = input$selected_files,
-                selected = input$selected_files,
-                multiple = TRUE, selectize = TRUE)
+    tagList(
+      selectizeInput(
+        "selected_multiple_files2",  
+        "Selected Players:", 
+        choices = input$selected_files,
+        selected = input$selected_files,
+        multiple = TRUE,
+        options = list(plugins = list('remove_button'))
+      ),
+      actionButton("select_all_players2", "Select All"),
+      actionButton("deselect_all_players2", "Reset")
+    )
   })
+  
+  
+  ####-------------'select and deselect all' buttons logic for file_selector_ui2 that is 'stats' tab------------
+  # Select all players (file_selector_ui2)
+  observeEvent(input$select_all_players2, {
+    req(input$selected_files)
+    updateSelectizeInput(
+      session,
+      "selected_multiple_files2",
+      selected = input$selected_files
+    )
+  })
+  
+  # Deselect all players (file_selector_ui2)
+  observeEvent(input$deselect_all_players2, {
+    updateSelectizeInput(
+      session,
+      "selected_multiple_files2",
+      selected = character(0)
+    )
+  })
+  ####-------------'select and deselect all' buttons logic for file_selector_ui2 that is 'stats' tab ENDS------------
+  
+  
+  
+  
   
   ##### Filter for maps
   output$file_selector_ui3 <- renderUI({
     req(input$selected_files)
     
-    selectInput("selected_data_file",
-                "Choose file to view data:",
-                choices = input$selected_files,
-                selected = input$selected_files[1])
+    selectizeInput("selected_data_file",
+                   "Selected Players: ",
+                   choices = input$selected_files,
+                   selected = input$selected_files[1],
+                   multiple = FALSE)
   })
   
   ##### Filter for photos
   output$file_selector_ui4 <- renderUI({
     req(input$selected_files)
     
-    selectInput("selected_data_file",
-                "Choose file to view data:",
-                choices = input$selected_files,
-                selected = input$selected_files[1])
+    selectizeInput("selected_data_file",
+                   "Selected Players: ",
+                   choices = input$selected_files,
+                   selected = input$selected_files[1],
+                   multiple = FALSE)
   })
   
   #####Big table code

--- a/app.R
+++ b/app.R
@@ -20,10 +20,10 @@ fetch_games_data_from_server <- function(url, token) {
   message("Fetched data, now processing...")
   # Adds a space between 'Bearer' and the token
   auth_header <- paste("Bearer", token)  
-
+  
   # Make the request with Authorization header
   res <- GET(url, add_headers(Authorization = auth_header))
-
+  
   # Handle the response
   if (status_code(res) == 200) {
     data <- fromJSON(content(res, "text", encoding = "UTF-8"))
@@ -136,6 +136,7 @@ ui <- page_sidebar(
         max-width: 100% !important;
       }
     }
+
     .selectize-control {
       width: 100% !important;
     }
@@ -150,6 +151,9 @@ ui <- page_sidebar(
       color: #000 !important;
       border: 1px solid #ffc107;
     }
+
+    
+
   '))
   ),
   
@@ -163,9 +167,9 @@ ui <- page_sidebar(
                  choices = c("Light", "Dark"),
                  inline = TRUE,
                  selected = "Light"),
-
-     # Upload JSON file section
-     div(style = "border: 1px solid #ccc; padding: 10px; margin-bottom: 5px; border-radius: 5px;",
+    
+    # Upload JSON file section
+    div(style = "border: 1px solid #ccc; padding: 10px; margin-bottom: 5px; border-radius: 5px;",
         fileInput("uploaded_json_file", "Upload JSON file:", accept = ".json", multiple = FALSE),
     ),
     
@@ -173,11 +177,11 @@ ui <- page_sidebar(
     conditionalPanel(
       condition = "typeof window.location.search.match(/token=([^&]+)/) !== 'undefined' && window.location.search.match(/token=([^&]+)/) !== null",
       div(style = "border: 1px solid #ccc; padding: 10px; margin-bottom: 15px; border-radius: 8px;",
-        selectizeInput(
-        inputId = "selected_games",
-        label = "Select your game:",
-        choices = NULL  # Leave it empty initially
-        )
+          selectizeInput(
+            inputId = "selected_games",
+            label = "Select your game:",
+            choices = NULL  # Leave it empty initially
+          )
       )
     ),
     
@@ -208,8 +212,8 @@ ui <- page_sidebar(
           actionButton("reset", "Reset", icon = icon("refresh"), style = "width:150px; margin-top: 10px; margin-bottom: 15px; margin-right: 15px"),
           textOutput("info_download"),
           actionButton("download_json", "Download", icon = icon("download"), style = "width:150px; margin-top: 10px; margin-bottom: 15px;")
-        )
-      ),
+      )
+    ),
     
     
     #filter 2 - ID - 2nd div
@@ -225,51 +229,161 @@ ui <- page_sidebar(
   
   # Main tabs
   tabsetPanel(
+    tabPanel(
+      'All tasks',
+      div(
+        style = "display: flex; justify-content: flex-start; gap: 40px; align-items: flex-start;
+             margin-top: 20px; margin-bottom: 15px;
+             border: 1px solid #ccc; padding: 10px;",
+        # Task filter
+        div(style = "min-width: 300px;", 
         uiOutput("task_id_selector")),
+        
+        # Player selector
+        div(style = "min-width: 300px;", 
         uiOutput("file_selector_ui"))
+      ),
+      
+      uiOutput("player_info_box"),
+      DTOutput('iris_data'),
+      div(
+        style = "border: 0px solid #ccc; padding: 10px; margin-top: 15px; border-radius: 8px;",
+        uiOutput('save_big_table')
+      )
+    ),
+    
+    tabPanel(
+      'Map',
       div(
         style = "display: flex; justify-content: flex-start; gap: 40px; align-items: flex-start;
              margin-top: 20px; margin-bottom: 15px;
              border: 1px solid #ccc; padding: 10px;",
         div(style = "min-width: 300px;", numericInput("num_value", "Selected Tasks:", value = 1, min = 1, max = 1)),
         div(style = "min-width: 300px;", uiOutput("file_selector_ui3"))
+      ),
+      textOutput("mapLegend"),
+      div(id="map", leafletOutput("map"), style = "margin-top: 5px"),
+      div(style = "border: 0px solid #ccc; padding: 10px; margin-top: 15px; border-radius: 8px;",
+          downloadButton('downloadMap','Save the map'), full_screen = TRUE)
+    ),
+    tabPanel(
+      'Pictures',
+      div(
         style = "display: flex; justify-content: flex-start; gap: 40px; align-items: flex-start;
              margin-top: 20px; margin-bottom: 15px;
              border: 1px solid #ccc; padding: 10px;",
         div(style = "min-width: 300px;", numericInput("num_value_pictures", "Selected Tasks:", value = 1, min = 1, max = 1)),
         div(style = "min-width: 300px;", uiOutput("file_selector_ui4"))
+      ),
+      card(uiOutput("photo_display"))
+    ),
+    tabPanel(
+      'Compare Players',
+      div(
         style = "display: flex; justify-content: flex-start; gap: 40px; align-items: flex-start;
            margin-top: 20px; margin-bottom: 15px;
            border: 1px solid #ccc; padding: 10px;",
         div(style = "min-width: 300px; max-width: 350px;", 
             numericInput("num_value_comparison", "Selected Tasks:", value = 1, min = 1, max = 1)
+        ),
         div(style = "flex: 1; max-width: 700px;", 
+            uiOutput("file_selector_ui1")
+        )
+        
+        #NOTE FOR SELECTIZE INPUT HANDLING THE MAXIMUM WIDTH OF CHOSEN PLAYERS IN 'COMPARISON' FROM THE ABOVE  - ADDED THE CODE WRITTEN BELOW IN THE CSS TAGS$HEAD$STYLE ABOVE,
+        # .selectize-control {
+        #   width: 100% !important;
+        # }
+        # .selectize-input {
+        #   width: 100% !important;
+        # }
+      ),
+      textOutput("tabLegend"),
+      conditionalPanel(
+        condition = "output.tabLegend == 'Task type: Navigation to flag' || output.tabLegend == 'Task type: Navigation with arrow' || output.tabLegend == 'Task type: Navigation via text' || output.tabLegend == 'Task type: Navigation via photo'",
+        card(h4("Route length versus time"), tableOutput('cmp_table1'), downloadButton('save_table1', 'Save to csv'), style = "margin-top: 10px")
+      ),
+      conditionalPanel(
+        condition = "output.tabLegend == 'Task type: Direction determination'",
+        card(h4("Answer and error for direction task"), tableOutput('cmp_table2'), downloadButton('save_table2', 'Save to csv'), style = "margin-top: 10px")
+      )
+    ),
+    tabPanel(
+      'Statistics',
+      div(
         style = "display: flex; justify-content: flex-start; gap: 40px; align-items: flex-start;
              margin-top: 20px; margin-bottom: 15px;
              border: 1px solid #ccc; padding: 10px;",
         div(style = "min-width: 300px;  max-width: 350px;", 
             numericInput("num_value_Statistics", "Selected Tasks:", value = 1, min = 1, max = 1)
+        ),
         div(style = "flex: 1; max-width: 700px;", 
+            uiOutput("file_selector_ui2")
+        )
+      ), 
+      # .selectize-control {
+      #   width: 100% !important;
+      # }
+      # .selectize-input {
+      #   width: 100% !important;
+      # }
+      
+      textOutput("graphLegend"),
+      #if the task category is navigation
+      conditionalPanel(condition = "output.graphLegend == 'Task type: Navigation to flag' || output.graphLegend == 'Task type: Navigation with arrow' || output.graphLegend == 'Task type: Navigation via text' || output.graphLegend == 'Task type: Navigation via photo'",
+                       selectInput(
+                         inputId = "graph_filter",
+                         label = "Choose graphic to display:",
+                         choices = c("Time VS Distance","Answer & Error"),
+                         selected = c("Answer & Error")
+                       ), conditionalPanel(
+                         condition = "input.graph_filter == 'Answer & Error'",
+                         card(card_header("Pie chart") , full_screen = TRUE, plotOutput('pie_chart'), 
+                              div(style = "border: 0px solid #ccc; padding: 10px; margin-top: 15px; border-radius: 8px;",
+                                  downloadButton('save_picture','Save to png')))
+                       ), conditionalPanel(
+                         condition = "input.graph_filter == 'Time VS Distance'",
+                         card(card_header("Time vs distance scatter plot"), full_screen = TRUE, plotOutput('time_chart'), 
+                              div(style = "border: 0px solid #ccc; padding: 10px; margin-top: 15px; border-radius: 8px;",
+                                  downloadButton('save_time_chart','Save to png')))
+                       )
+      ),
+      #else, for the other tasks
+      conditionalPanel(condition = "output.graphLegend == 'Task type: Direction determination' || output.graphLegend == 'Task type: Free' || output.graphLegend == 'Task type: Self location' || output.graphLegend == 'Task type: Object location'",
+                       selectInput(
+                         inputId = "graph_filter2",
+                         label = "Choose graphic to display:",
+                         choices = c("Answer & Error"),
+                         selected = c("Answer & Error")
+                       ), conditionalPanel(
+                         condition = "input.graph_filter2 == 'Answer & Error'",
+                         card(card_header("Time vs distance scatter plot"), full_screen = TRUE, plotOutput('pie_chart2'),
+                              div(style = "border: 0px solid #ccc; padding: 10px; margin-top: 15px; border-radius: 8px;",
+                                  downloadButton('save_picture2','Save to png')))
+                       ),
+      ),
+    )
+  )
 )
 
 
 server <- function(input, output, session) {
-
+  
   # Store selected game track data reactively
   selected_game_tracks_rv <- reactiveVal()
   # Store access token reactively
   accessToken_rv <- reactiveVal()
   track_data_rv <- reactiveVal()
   apiURL_rv <- reactiveVal("https://api.geogami.ifgi.de")
-
+  
   # Observe the URL query string for the token parameter
   observe({
     query <- parseQueryString(session$clientData$url_search)
     tokenParam <- query[["token"]]
     accessToken_rv(tokenParam)
   })
-
-    # Theme options
+  
+  # Theme options
   observe({
     if (input$theme == "Dark") {
       session$setCurrentTheme(bs_theme(bootswatch = "solar"))
@@ -277,8 +391,8 @@ server <- function(input, output, session) {
       session$setCurrentTheme(bs_theme(bootswatch = "flatly"))
     }
   })
-
-    output$text <- renderText({
+  
+  output$text <- renderText({
     paste("Current theme is:", input$theme)
   })
   
@@ -295,28 +409,28 @@ server <- function(input, output, session) {
       games_name <- games_data$name
       games_id <- games_data[["_id"]]
     }
-
+    
     ### 2. Populate select input for games
     updateSelectizeInput(session, "selected_games",
-                          choices = setNames(games_id, games_name),
-                          server = TRUE)
-  
+                         choices = setNames(games_id, games_name),
+                         server = TRUE)
+    
     output$info_download <- renderText({
-        ""
-      })
+      ""
+    })
   })
   
   ### 3. When a game is selected
   observeEvent(input$selected_games, {
     game_id <- input$selected_games
-
+    
     # update the API URL with the selected game ID
     apiUrl <- paste0(apiURL_rv(), "/track/gametracks/", game_id)
     
     # Fetch game's tracks data from API
     # Note: The token is used for authentication, ensure it is valid
     games_tracks <- fetch_games_data_from_server(apiUrl, accessToken_rv())
-
+    
     # Store in reactive value
     selected_game_tracks_rv(games_tracks)
   })
@@ -333,15 +447,15 @@ server <- function(input, output, session) {
       )
       
       updateSelectizeInput(session, "selected_files",
-                          choices = choices,
-                          server = TRUE)
-
+                           choices = choices,
+                           server = TRUE)
+      
       output$info_download <- renderText({
         ""
       })
     }
   })
-
+  
   # Download json file
   output$download_json <- downloadHandler(
     filename = function() {
@@ -351,12 +465,12 @@ server <- function(input, output, session) {
     content = function(file) {
       req(input$selected_files)  # Ensure some files are selected
       list_to_save <- track_data_rv()  # Your reactive list
-
+      
       # Save to JSON
       jsonlite::write_json(list_to_save, path = file, pretty = TRUE, auto_unbox = TRUE, digits = NA)
     }
   )
-
+  
   ### 5. Reset file selector when reset button clicked
   observeEvent(input$reset, {
     tracks_data <- selected_game_tracks_rv()
@@ -368,27 +482,28 @@ server <- function(input, output, session) {
       )
       
       updateSelectizeInput(session, "selected_files",
-                          choices = choices,
-                          selected = NULL,
-                          server = TRUE)
+                           choices = choices,
+                           selected = NULL,
+                           server = TRUE)
     }
   })
-
+  
   # 6. Select single file to view
   output$file_selector_ui <- renderUI({
     req(input$selected_files)
-
-    selectInput("selected_data_file",
-                "Choose file to view data:",
-                choices = input$selected_files,
-                selected = input$selected_files[1])
+    
+    selectizeInput("selected_data_file",
+                   "Selected Players:",
+                   choices = input$selected_files,
+                   selected = input$selected_files[1],
+                   multiple = FALSE)
   })
   
   ### 7. Reactive: load selected single file data
   loaded_json <- reactive({
     req(input$selected_data_file)
     selected <- input$selected_data_file
-
+    
     lapply(selected, function(file) {
       track_id <- input$selected_data_file
       # Construct the API URL
@@ -399,24 +514,24 @@ server <- function(input, output, session) {
       return(track_data)
     })
   })
-
+  
   #Get the uploaded json file
   uploaded_json <- reactive({
     req(input$uploaded_json_file)
     datapaths <- input$uploaded_json_file$datapath
     
     lapply(datapaths, function(path) {
-     jsonlite::fromJSON(path)
+      jsonlite::fromJSON(path)
     })
   })
-
+  
   ### 8. Reactive: load multiple json files for comparison
   load_multiple <- reactive({
     req(input$selected_multiple_files)
-
+    
     # If multiple IDs are found, use only the last one
     sel <- input$selected_multiple_files[length(input$selected_multiple_files)]
-
+    
     lapply(sel, function(file) {
       track_id <- sel
       # Construct the API URL
@@ -542,68 +657,68 @@ server <- function(input, output, session) {
   
   #####Big table code
   df_react <- reactiveVal()
-
-observeEvent(req(input$selected_data_file, input$num_value), {
-  req(input$num_value != 0 && input$num_value > 0)
   
-  data <- loaded_json()  # load selected JSON
-  
-  if (is.null(data) || length(data) == 0) {
-    showNotification("No data found for selected file.", type = "error")
-    return()
-  }
-
-  # Defensive check: ensure expected structure exists
-  if (!("events" %in% names(data[[1]])) || !("task" %in% names(data[[1]]$events))) {
-    showNotification("Unexpected data format.", type = "error")
-    return()
-  }
-
-  id <- data[[1]]$events$task[["_id"]]
-  typ <- list()
-  cons <- list()
-  ans <- list()
-
-  # Extract reusable fields
-  csg <- data[[1]]$events$task$question$text
-  ev <- data[[1]]$events$type
-  pict_quest <- data[[1]]$events$task$question$photo
-  ans_type <- data[[1]]$events$task$answer$type
-  
-  for (j in seq_len(length(id) - 1)) {
-    if ((!is.na(id[j]) && (id[j] != id[j + 1])) || j == (length(id) - 1)) {
-      correct_flag <- data[[1]]$events$answer$correct[j]
-      
-      ans_value <- NA  # Default
-
-      if (ans_type[j] == "TEXT") {
-        ans_text <- data[[1]]$events$answer$text[j]
-        if (!is.na(correct_flag)) {
-          ans_value <- paste(ifelse(correct_flag == "TRUE", "Correct", "Incorrect"), ans_text)
-        }
-      } else if (ans_type[j] == "MULTIPLE_CHOICE_TEXT") {
-        choice_val <- data[[1]]$events$answer$selectedChoice$value[j]
-        if (!is.na(correct_flag)) {
-          ans_value <- paste(ifelse(correct_flag == "TRUE", "Correct", "Incorrect"), choice_val)
-        }
-      } else if (ans_type[j] == "NUMBER") {
-        num_val <- data[[1]]$events$answer$numberInput[j]
-        if (!is.na(correct_flag)) {
-          ans_value <- paste(ifelse(correct_flag == "TRUE", "Correct", "Incorrect"), num_val)
-        }
-      } else {
-        # Fallback for unknown types
-        if (!is.null(correct_flag)) {
-          ans_value <- ifelse(correct_flag == "TRUE", "Correct", "Incorrect")
-        }
-      }
-
-      ans <- append(ans, ans_value)
-      typ <- append(typ, data[[1]]$events$task$type[j])
-      cons <- append(cons, csg[j])
+  observeEvent(req(input$selected_data_file, input$num_value), {
+    req(input$num_value != 0 && input$num_value > 0)
+    
+    data <- loaded_json()  # load selected JSON
+    
+    if (is.null(data) || length(data) == 0) {
+      showNotification("No data found for selected file.", type = "error")
+      return()
     }
-  }
-
+    
+    # Defensive check: ensure expected structure exists
+    if (!("events" %in% names(data[[1]])) || !("task" %in% names(data[[1]]$events))) {
+      showNotification("Unexpected data format.", type = "error")
+      return()
+    }
+    
+    id <- data[[1]]$events$task[["_id"]]
+    typ <- list()
+    cons <- list()
+    ans <- list()
+    
+    # Extract reusable fields
+    csg <- data[[1]]$events$task$question$text
+    ev <- data[[1]]$events$type
+    pict_quest <- data[[1]]$events$task$question$photo
+    ans_type <- data[[1]]$events$task$answer$type
+    
+    for (j in seq_len(length(id) - 1)) {
+      if ((!is.na(id[j]) && (id[j] != id[j + 1])) || j == (length(id) - 1)) {
+        correct_flag <- data[[1]]$events$answer$correct[j]
+        
+        ans_value <- NA  # Default
+        
+        if (ans_type[j] == "TEXT") {
+          ans_text <- data[[1]]$events$answer$text[j]
+          if (!is.na(correct_flag)) {
+            ans_value <- paste(ifelse(correct_flag == "TRUE", "Correct", "Incorrect"), ans_text)
+          }
+        } else if (ans_type[j] == "MULTIPLE_CHOICE_TEXT") {
+          choice_val <- data[[1]]$events$answer$selectedChoice$value[j]
+          if (!is.na(correct_flag)) {
+            ans_value <- paste(ifelse(correct_flag == "TRUE", "Correct", "Incorrect"), choice_val)
+          }
+        } else if (ans_type[j] == "NUMBER") {
+          num_val <- data[[1]]$events$answer$numberInput[j]
+          if (!is.na(correct_flag)) {
+            ans_value <- paste(ifelse(correct_flag == "TRUE", "Correct", "Incorrect"), num_val)
+          }
+        } else {
+          # Fallback for unknown types
+          if (!is.null(correct_flag)) {
+            ans_value <- ifelse(correct_flag == "TRUE", "Correct", "Incorrect")
+          }
+        }
+        
+        ans <- append(ans, ans_value)
+        typ <- append(typ, data[[1]]$events$task$type[j])
+        cons <- append(cons, csg[j])
+      }
+    }
+    
     # print(cons)
     # print(typ)
     #print(cbind(data[[1]]$events$task$type, data[[1]]$events$correct,data[[1]]$events$answer$correct))
@@ -944,6 +1059,11 @@ observeEvent(req(input$selected_data_file, input$num_value), {
     
     df_react(df)
     
+    # observe({
+    #   updateNumericInput(session, "num_value_tasks", 
+    #                      max = nrow(df_react()))
+    # })
+    
     observe({
       updateNumericInput(session, "num_value", 
                          max = nrow(df_react()))
@@ -964,9 +1084,16 @@ observeEvent(req(input$selected_data_file, input$num_value), {
                          max = nrow(df_react()))
     })
     
+    #all_ids <- c("num_value", "num_value_map", "num_value_pictures", "num_value_comparison", "num_value_Statistics")
+    #NOTE : num_value is the important variable, all of the other stored elements are triggered because of 'num_value'
+    
     output$iris_data <- renderDT({
       df_react()
     })
+    
+    
+    
+    
     #-----------all tasks - id checkbox filter starts --------------------------------
     output$task_id_selector <- renderUI({
       req(df_react())
@@ -2123,12 +2250,20 @@ observeEvent(req(input$selected_data_file, input$num_value), {
       )
     })
     
+    
+    
     df_react(df)
+    
+    # observe({
+    #   updateNumericInput(session, "num_value_tasks", 
+    #                      max = nrow(df_react()))
+    # })
     
     observe({
       updateNumericInput(session, "num_value", 
                          max = nrow(df_react()))
     })
+    
     observe({
       updateNumericInput(session, "num_value_pictures", 
                          max = nrow(df_react()))
@@ -2144,10 +2279,16 @@ observeEvent(req(input$selected_data_file, input$num_value), {
                          max = nrow(df_react()))
     })
     
+    #all_ids <- c("num_value", "num_value_map", "num_value_pictures", "num_value_comparison", "num_value_Statistics")
+    #NOTE : num_value is the important variable, all of the other stored elements are triggered because of 'num_value'
     
     output$iris_data <- renderDT({
       df_react()
     })
+    
+    
+    
+    
     #-----------all tasks - id checkbox filter starts --------------------------------
     output$task_id_selector <- renderUI({
       req(df_react())
@@ -2502,6 +2643,26 @@ observeEvent(req(input$selected_data_file, input$num_value), {
   
   
   #Download big table
+  #REMOVING THE OLD BIG TABLE - COMMENTING IT FOR NOW
+  # output$save_data <- downloadHandler(
+  #   filename = function(){
+  #     paste("data_", Sys.Date(), ".csv", sep="")
+  #   },
+  #   content = function(file){
+  #     write.csv(df_react(), file)
+  #   }
+  # )
+  # 
+  # output$save_big_table <- renderUI({
+  #   req(input$selected_data_file)
+  #   
+  #   if (length(input$selected_data_file) > 0 && input$selected_data_file != "") {
+  #     downloadButton('save_data', 'Save to csv')
+  #   }
+  # })
+  
+  
+  
   all_ids <- c("num_value", "num_value_pictures", "num_value_comparison", "num_value_Statistics")
   #NOTE : num_value is the important variable, all of the other stored elements are triggered because of 'num_value'
   
@@ -2519,6 +2680,10 @@ observeEvent(req(input$selected_data_file, input$num_value), {
         }
       }, ignoreInit = TRUE, ignoreNULL = TRUE)
     })
+  }
+  
+  
+  
   
 }
 


### PR DESCRIPTION
1. Limiting the id selection to maximum no. of rows present in the 'original data frame' and not the filtered data frame 

2. Bringing Id (numericInput) reactivity in all 4 main panels (maps, pictures, compare , statistics) 
a. excluding the all tasks - id selection 'reactivity' from the rest of the main panels 

3. In All Main panels -
 a. css elements alignment both beside each other and more CSS changes accordingly
  b. CSS - Responsive to tablet, hover over the main tabs, etc. c. Changing 'NAMES' of tasks and players selection 
  
  4. filtering 'all tasks' big table based on ids selected 
  a. download filtered csv feature 
  b. dropdown checkboxes in ids 
  c. For multiple file selection in 'compare' and 'stats', getting the same delete buttons beside -  i.e 'x' , 'SELECT ALL' , 'DESELECT ALL'