### PR TITLE
Comparison tabs issue/keyboard issue for games also solved/reset button renamed

### DIFF
--- a/app.R
+++ b/app.R
@@ -576,33 +576,36 @@ server <- function(input, output, session) {
         choices = choices_rv(),
                 selected = input$selected_files,
         multiple = TRUE
-      ),
-      # Add select/deselect buttons
-      actionButton("select_all_players", "Select All"),
-      actionButton("deselect_all_players", "Reset")
+      )
+      # ,
+      # # Add select/deselect buttons
+      # actionButton("select_all_players", "Select All"),
+      # actionButton("deselect_all_players", "Select None")
     )
   })
   
   
   ####-------------'select and deselect all' buttons logic for file_selector_ui 1 that is 'compare' tab------------
   # Select all players
-  observeEvent(input$select_all_players, {
-    req(input$selected_files)
-    updateSelectInput(
-      session,
-      "selected_multiple_files",
-      selected = input$selected_files
-    )
-  })
-  
-  # Deselect all players
-  observeEvent(input$deselect_all_players, {
-    updateSelectInput(
-      session,
-      "selected_multiple_files",
-      selected = character(0)
-    )
-  })
+  # observeEvent(input$select_all_players, {
+  #   req(choices_rv())
+  #   req(input$selected_files)
+  #   updateSelectInput(
+  #     session,
+  #     "selected_multiple_files",
+  #     selected = input$selected_files
+  #   )
+  # })
+  # 
+  # # Deselect all players
+  # observeEvent(input$deselect_all_players, {
+  #   req(choices_rv())
+  #   updateSelectInput(
+  #     session,
+  #     "selected_multiple_files",
+  #     selected = character(0)
+  #   )
+  # })
   ####-------------'select and deselect all' buttons logic for file_selector_ui 1 that is 'compare' tab ENDS------------
   
   
@@ -616,37 +619,40 @@ server <- function(input, output, session) {
     
     tagList(
       selectInput(
-        "selected_multiple_files2",  
+        "selected_multiple_files",  
         "Selected Players:", 
         choices = choices_rv(),
                 selected = input$selected_files,
         multiple = TRUE
-      ),
-      actionButton("select_all_players2", "Select All"),
-      actionButton("deselect_all_players2", "Reset")
+      )
+      # ,
+      # actionButton("select_all_players2", "Select All"),
+      # actionButton("deselect_all_players2", "Select None")
     )
   })
   
   
   ####-------------'select and deselect all' buttons logic for file_selector_ui2 that is 'stats' tab------------
   # Select all players (file_selector_ui2)
-  observeEvent(input$select_all_players2, {
-    req(input$selected_files)
-    updateSelectInput(
-      session,
-      "selected_multiple_files2",
-      selected = input$selected_files
-    )
-  })
-  
-  # Deselect all players (file_selector_ui2)
-  observeEvent(input$deselect_all_players2, {
-    updateSelectInput(
-      session,
-      "selected_multiple_files2",
-      selected = character(0)
-    )
-  })
+  # observeEvent(input$select_all_players2, {
+  #   req(choices_rv())
+  #   req(input$selected_files)
+  #   updateSelectInput(
+  #     session,
+  #     "selected_multiple_files2",
+  #     selected = input$selected_files
+  #   )
+  # })
+  # 
+  # # Deselect all players (file_selector_ui2)
+  # observeEvent(input$deselect_all_players2, {
+  #   req(choices_rv())
+  #   updateSelectInput(
+  #     session,
+  #     "selected_multiple_files2",
+  #     selected = character(0)
+  #   )
+  # })
   ####-------------'select and deselect all' buttons logic for file_selector_ui2 that is 'stats' tab ENDS------------
   
   


### PR DESCRIPTION
1- solved the comparison tabs file_selector_ui1 and file_selector_ui2 issues, statistics tab's UI selector _2 was not responding , now works, also, it is better to delete these action buttons, they are of no use here, and if we keep them then there will be a lot many changes required, if we want to remove some of the fiiles, we can click on reset in the sidebar and load only the ones which we want to compare, so action buttons from both of these fileselector_ui1 and file_selector_ui2 can be removed, they were also not asked by professor angela to be added, i just added them to have some extra functionality.


2- name change of reset button in 'All plays' from 'reset' to -> 'select None'


3- for games selection also changed it from selectizeInput -> to -> selectInput (for solving keyboard issue)